### PR TITLE
Container Image Build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,10 @@ ENV PYTHONDONTWRITEBYTECODE 1
 ENV PYTHONUNBUFFERED 1
 
 WORKDIR /app
+COPY bin/helium-config-service-cli /usr/local/bin/hpr
+COPY app/* .
 COPY requirements.txt .
 RUN pip install -r requirements.txt
+
+ENTRYPOINT ["python3", "app.py"]
 #RUN pip install --no-cache-dir -r requirements.txt


### PR DESCRIPTION
Produces a working container image with the helium-config-service-cli tool in the path and a valid entry point.

The Good:
- Produces a working container image 🥳 

The Bad:
- The binary release of helium-config-service-cli is stored in the binary folder of this repo and has to be manually updated each time Nova release 🤮 

Stuff to make it better:
- Maybe Github actions to pull in the latest release of helium-config-service-cli dynamically and run a docker build before pushing to Github Container Registry as a release.