### PR TITLE
Fail if Helium delegate key isn't Ed25519

### DIFF
--- a/app/ChirpHeliumCrypto.py
+++ b/app/ChirpHeliumCrypto.py
@@ -22,7 +22,20 @@ route_id = os.getenv('ROUTE_ID', None)
 delegate_key = os.getenv('HELIUM_KEYPAIR_BIN', default=None)
 
 with open(delegate_key, 'rb') as f:
-    skey = f.read()[1:65]
+    blob = f.read()[:65]
+    key_net_and_type, skey = blob[0], blob[1:65]
+    KEY_TYPE_ED25519 = 1
+    if (key_net_and_type & 0x0f) != KEY_TYPE_ED25519:
+        # The Helium blockchain historically supported two
+        # different key types: Ed25519 and ECC Compact.
+        # ECC Compact requires different code, which we don't have
+        # at the moment.
+        warning = \
+            "Unsupported delegate private key type. Only Ed25519 " \
+            "keys are supported."
+        logging.error(warning)
+        raise Exception(warning)
+
     delegate_keypair = Keypair(
         SodiumKeyPair(
             sk=skey,


### PR DESCRIPTION
Fix an issue where the code wasn't checking the key type of the Helium delegate key. If the key type isn't Ed25519, the code will appear to run just fine but will not generate proper delegation transactions, which is very hard to debug.

It might not be too hard support ECC_COMPACT in the future, but it definitely doesn't work right now and it should be clear about that.

Addresses issue #96 by crashing very vocally.