### PR TITLE
fix: parameterize helium_devices upsert queries to close SQL injection

### DIFF
--- a/app/ChirpHeliumJoinRpc.py
+++ b/app/ChirpHeliumJoinRpc.py
@@ -47,10 +47,10 @@ class ChirpstackJoins:
         self.cs_grpc = chirpstack_host
         self.auth_token = [("authorization", f"Bearer {chirpstack_token}")]
 
-    def db_transaction(self, query: str):
+    def db_transaction(self, query: str, params=None):
         with psycopg2.connect(self.postgres) as con:
             with con.cursor() as cur:
-                cur.execute(query)
+                cur.execute(query, params)
 
     ###########################################################################
     # follow internal redis stream gRPC for actionable changes
@@ -139,25 +139,26 @@ class ChirpstackJoins:
         query = """
             INSERT INTO helium_devices
             (dev_eui, join_eui, dev_addr, max_copies, aps_key, nws_key, dev_name, fcnt_up, fcnt_down)
-            VALUES ('{0}', '{1}', '{2}', '{3}', '{4}', '{5}', '{6}', '{7}', '{8}')
+            VALUES (%(dev_eui)s, %(join_eui)s, %(dev_addr)s, %(max_copies)s, %(aps_key)s, %(nws_key)s, %(dev_name)s, %(fcnt_up)s, %(fcnt_down)s)
             ON CONFLICT (dev_eui) DO UPDATE
-            SET join_eui = '{1}',
-                dev_addr = '{2}',
-                max_copies = '{3}',
-                aps_key = '{4}',
-                nws_key = '{5}',
-                dev_name = '{6}',
-                fcnt_up = '{7}',
-                fcnt_down = '{8}';
-        """.format(
-            devices["devEui"],
-            devices["joinEui"],
-            devices["devAddr"],
-            max_copies,
-            devices["appSKey"],
-            devices["nwkSEncKey"],
-            devices["name"],
-            devices["fCntUp"],
-            devices["nFCntDown"],
-        )
-        self.db_transaction(query)
+            SET join_eui = EXCLUDED.join_eui,
+                dev_addr = EXCLUDED.dev_addr,
+                max_copies = EXCLUDED.max_copies,
+                aps_key = EXCLUDED.aps_key,
+                nws_key = EXCLUDED.nws_key,
+                dev_name = EXCLUDED.dev_name,
+                fcnt_up = EXCLUDED.fcnt_up,
+                fcnt_down = EXCLUDED.fcnt_down;
+        """
+        params = {
+            "dev_eui": devices["devEui"],
+            "join_eui": devices["joinEui"],
+            "dev_addr": devices["devAddr"],
+            "max_copies": max_copies,
+            "aps_key": devices["appSKey"],
+            "nws_key": devices["nwkSEncKey"],
+            "dev_name": devices["name"],
+            "fcnt_up": devices["fCntUp"],
+            "fcnt_down": devices["nFCntDown"],
+        }
+        self.db_transaction(query, params)

--- a/app/ChirpHeliumKeysRpc.py
+++ b/app/ChirpHeliumKeysRpc.py
@@ -75,10 +75,10 @@ class ChirpDeviceKeys:
         await db.close()
         return cur
 
-    def db_transaction(self, query: str):
+    def db_transaction(self, query: str, params=None):
         with psycopg2.connect(self.postgres) as con:
             with con.cursor() as cur:
-                cur.execute(query)
+                cur.execute(query, params)
 
     async def async_db_transaction(self, query: str):
         db = Database()
@@ -151,28 +151,29 @@ class ChirpDeviceKeys:
         query = """
             INSERT INTO helium_devices
             (dev_eui, join_eui, dev_addr, max_copies, aps_key, nws_key, dev_name, fcnt_up, fcnt_down)
-            VALUES ('{0}', '{1}', '{2}', '{3}', '{4}', '{5}', '{6}', '{7}', '{8}')
+            VALUES (%(dev_eui)s, %(join_eui)s, %(dev_addr)s, %(max_copies)s, %(aps_key)s, %(nws_key)s, %(dev_name)s, %(fcnt_up)s, %(fcnt_down)s)
             ON CONFLICT (dev_eui) DO UPDATE
-            SET join_eui = '{1}',
-                dev_addr = '{2}',
-                max_copies = '{3}',
-                aps_key = '{4}',
-                nws_key = '{5}',
-                dev_name = '{6}',
-                fcnt_up = '{7}',
-                fcnt_down = '{8}';
-        """.format(
-            devices["devEui"],
-            devices["joinEui"],
-            devices["devAddr"],
-            max_copies,
-            devices["appSKey"],
-            devices["nwkSEncKey"],
-            devices["name"],
-            devices["fCntUp"],
-            devices["nFCntDown"],
-        )
-        self.db_transaction(query)
+            SET join_eui = EXCLUDED.join_eui,
+                dev_addr = EXCLUDED.dev_addr,
+                max_copies = EXCLUDED.max_copies,
+                aps_key = EXCLUDED.aps_key,
+                nws_key = EXCLUDED.nws_key,
+                dev_name = EXCLUDED.dev_name,
+                fcnt_up = EXCLUDED.fcnt_up,
+                fcnt_down = EXCLUDED.fcnt_down;
+        """
+        params = {
+            "dev_eui": devices["devEui"],
+            "join_eui": devices["joinEui"],
+            "dev_addr": devices["devAddr"],
+            "max_copies": max_copies,
+            "aps_key": devices["appSKey"],
+            "nws_key": devices["nwkSEncKey"],
+            "dev_name": devices["name"],
+            "fcnt_up": devices["fCntUp"],
+            "fcnt_down": devices["nFCntDown"],
+        }
+        self.db_transaction(query, params)
         # await self.async_db_transaction(query)
         return f"Updated: {dev_eui}"
 


### PR DESCRIPTION
## Summary
- Device names (and other per-device fields) were interpolated directly into INSERT/UPDATE SQL via `.format()`, so a name containing a single quote (e.g. `Charles' Chicken Co.`) broke the query -- and any value could inject arbitrary SQL.
- Switched to psycopg2 parameterized queries (`%(name)s`) with `EXCLUDED.col` on conflict, in `ChirpHeliumKeysRpc.py` and `ChirpHeliumJoinRpc.py`.

## Test plan
- [x] Built and deployed image to a live cluster on this branch
- [x] Renamed a real device to `Charles' Chicken Coop Temp Sensor` (reproduces the original crash) -- confirmed stored verbatim, no syntax error
- [x] Set `max_copies` variable to `3'; SELECT pg_sleep(5); --` -- no timing anomaly, no stacked query execution
- [x] Confirmed via direct DB query that values land as literal text, not SQL

Note: unrelated pre-existing issue found during testing -- `update_device_status`'s `run_every` loop throws `sleep length must be non-negative` once the device list grows large enough that one pass exceeds the 300s interval. Not touched here; flagging separately.