### PR TITLE
fix: cast max_copies device variable to int for asyncpg binding

### DIFF
--- a/app/ChirpHeliumJoinRpc.py
+++ b/app/ChirpHeliumJoinRpc.py
@@ -113,7 +113,7 @@ class ChirpstackJoins:
 
         max_copies = 0
         if devices.get("variables") and "max_copies" in devices.get("variables"):
-            max_copies = devices["variables"]["max_copies"]
+            max_copies = int(devices["variables"]["max_copies"])
         if "fCntUp" not in devices.keys():
             devices["fCntUp"] = 0
         if "nFCntDown" not in devices.keys():

--- a/app/ChirpHeliumKeysRpc.py
+++ b/app/ChirpHeliumKeysRpc.py
@@ -77,7 +77,7 @@ class ChirpDeviceKeys:
 
         max_copies = 0
         if devices.get("variables") and "max_copies" in devices.get("variables"):
-            max_copies = devices["variables"]["max_copies"]
+            max_copies = int(devices["variables"]["max_copies"])
         if "fCntUp" not in devices.keys():
             devices["fCntUp"] = 0
         if "nFCntDown" not in devices.keys():


### PR DESCRIPTION
ChirpStack device "variables" are always strings, so a custom max_copies variable (e.g. '12') was passed as-is into the $4 positional parameter for an integer column. psycopg2 tolerated this via implicit SQL-side casting; asyncpg binds parameters by type and rejects a str where an int is expected, raising:
"invalid input for query argument $4: '12' ('str' object cannot be interpreted as an integer)".