### PR TITLE
fix: use PAT instead of default GITHUB_TOKEN for tag/release creation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,6 +24,11 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          # Tags/releases created with the default GITHUB_TOKEN don't trigger
+          # other workflows (GitHub blocks this to prevent infinite loops),
+          # so build-container-image.yml's `release: published` trigger would
+          # never fire. Use the PAT already stored for ghcr.io pushes instead.
+          token: ${{ secrets.GH_TOKEN }}
 
       - name: Compute next version
         id: version
@@ -47,7 +52,7 @@ jobs:
 
       - name: Create GitHub release
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
         run: |
           gh release create "${{ steps.version.outputs.tag }}" \
             --title "${{ steps.version.outputs.tag }}" \


### PR DESCRIPTION
Tags and releases created with the default GITHUB_TOKEN don't trigger downstream workflows -- GitHub blocks this to prevent infinite trigger loops. That meant build-container-image.yml's "release: published" trigger never fired, and the image only ever got tagged "latest" (from the push-to-master trigger), never stamped with the release version. Switched to the GH_TOKEN PAT already used elsewhere in this repo for ghcr.io pushes.